### PR TITLE
Add counter of number of users with each recipe

### DIFF
--- a/app/models/share.rb
+++ b/app/models/share.rb
@@ -11,6 +11,11 @@ class Share < ApplicationRecord
 
   scope :with_other_user, lambda { where("sender_id != recipient_id OR recipient_id IS NULL") }
 
+  def number_of_users_with_recipe
+    @number_of_users_with_recipe ||= User.joins(:received_shares).
+      where(shares: { recipe_id: recipe.id }).count
+  end
+
   def generate_token
      self.token = Digest::SHA1.hexdigest(
        [self.recipe_id, self.sender_id, Time.now].join

--- a/app/views/shares/_table.html.erb
+++ b/app/views/shares/_table.html.erb
@@ -3,6 +3,7 @@
     <tr>
       <th>Recipe</th>
       <th>Shared By</th>
+      <th>:Parrots:</th>
     </tr>
   </thead>
   <tbody>
@@ -10,6 +11,7 @@
       <tr>
         <td><%= link_to "#{share.recipe.name}", share.recipe %></td>
         <td><%= share.sender == current_user ? "Mine!" : share.sender.full_name %></td>
+        <td><%= share.number_of_users_with_recipe %></td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/models/share_spec.rb
+++ b/spec/models/share_spec.rb
@@ -48,4 +48,14 @@ RSpec.describe Share, type: :model do
       expect { share.save }.to change { share.token }.from(nil).to be_present
     end
   end
+
+  describe "#number_of_users_with_recipe" do
+    it "is the number of distinct users that have access to the recipe" do
+      share = FactoryGirl.create(:share, :with_self)
+      FactoryGirl.create(:share, :with_existing_user, recipe: share.recipe)
+      FactoryGirl.create(:share, recipe: share.recipe)
+
+      expect(share.number_of_users_with_recipe).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a count in the shares screen to show the total number of other users that can see each recipe.