### PR TITLE
Separate authorization from user model

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,11 +2,11 @@ class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:create]
 
   def create
-    user = User.from_omniauth(request.env["omniauth.auth"])
-    session[:user_id] = user.id
+    auth = Authorization.from_omniauth(request.env["omniauth.auth"])
+    session[:user_id] = auth.user.id
 
     if share.present?
-      share.update!(recipient: user)
+      share.update!(recipient: auth.user)
     end
 
     redirect_to shares_path

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,0 +1,15 @@
+class Authorization < ApplicationRecord
+  validates :uid, :provider, presence: true
+  validates :uid, uniqueness: { scope: :provider }
+
+  belongs_to :user
+
+  def self.from_omniauth(auth, user=nil)
+    user ||= User.from_omniauth(auth)
+
+    where(provider: auth.provider, uid: auth.uid).first_or_initialize.tap do |auth|
+      auth.user = user
+      auth.save!
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ApplicationRecord
-  validates :uid, :provider, :email, presence: true
-  validates :uid, uniqueness: { scope: :provider }
   validates :email, uniqueness: true
   validates :email, email_format: true
 
@@ -10,15 +8,14 @@ class User < ApplicationRecord
   has_many :received_shares, foreign_key: :recipient_id, class_name: "Share"
   has_many :received_recipes, through: :received_shares, source: :recipe
 
+  has_many :authorizations
+
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_initialize.tap do |user|
-      user.first_name = auth.info.first_name
-      user.last_name = auth.info.last_name
-      user.email = auth.info.email
-      user.oauth_token = auth.credentials.token
-      user.oauth_expires_at = Time.at(auth.credentials.expires_at)
-      user.save!
-    end
+    where(email: auth.info.email).first_or_create(
+      first_name: auth.info.first_name,
+      last_name: auth.info.last_name,
+      password_digest: "NA",
+    )
   end
 
   def full_name

--- a/spec/factories/authorizations.rb
+++ b/spec/factories/authorizations.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :authorization do
+    provider "MyString"
+    uid "MyString"
+    association :user, factory: :user
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,11 +1,7 @@
 FactoryGirl.define do
   factory :user do
-    provider "google_oauth2"
-    sequence :uid { |n| "#{n}" }
     first_name "John"
     last_name "Doe"
     sequence :email { |n| "John@domain#{n}.test" }
-    oauth_token "token"
-    oauth_expires_at Time.now + 1.day
   end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Authorization, type: :model do
+  let(:authorization) { FactoryGirl.create(:authorization) }
+
+  it "is invalid without a user" do
+    authorization.user = nil
+    expect(authorization).to be_invalid
+  end
+
+  it "is invalid if uid is missing" do
+    authorization.uid = nil
+    expect(authorization).to be_invalid
+  end
+
+  it "is invalid if provider is missing" do
+    authorization.provider = nil
+    expect(authorization).to be_invalid
+  end
+
+  it "is invalid if uid is duplicated with the same provider" do
+    new_authorization = FactoryGirl.build(:authorization, uid: authorization.uid, provider: authorization.provider)
+    expect(new_authorization).to be_invalid
+  end
+
+  it "is valid if uid is duplicated with different providers" do
+    new_authorization = FactoryGirl.build(:authorization, uid: authorization.uid, provider: "other provider")
+    expect(new_authorization).to be_valid
+  end
+
+  describe ".from_omniauth" do
+    subject { Authorization.from_omniauth(OmniAuth.config.mock_auth[:google_oauth2]) }
+
+    it "creates a new authorization" do
+      expect { subject }.to change { Authorization.count }.from(0).to(1)
+    end
+
+    it "creates one authorization when called twice with the same parameters" do
+      expect { subject }.to change { Authorization.count }.from(0).to(1)
+      expect { subject }.to_not change { Authorization.count }
+    end
+
+    it "creates an authorization with the expected provider" do
+      expect(subject.provider).to eq("google_oauth2")
+    end
+
+    it "creates an authorization with the expected uid" do
+      expect(subject.uid).to eq("123456789")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,29 +8,14 @@ RSpec.describe User, type: :model do
     expect(user).to be_invalid
   end
 
-  it "is invalid if uid is missing" do
-    user.uid = nil
-    expect(user).to be_invalid
-  end
-
-  it "is invalid if provider is missing" do
-    user.provider = nil
-    expect(user).to be_invalid
-  end
-
-  it "is invalid if uid is duplicated with the same provider" do
-    new_user = FactoryGirl.build(:user, uid: user.uid, provider: user.provider)
-    expect(new_user).to be_invalid
-  end
-
-  it "is valid if uid is duplicated with different providers" do
-    new_user = FactoryGirl.build(:user, uid: user.uid, provider: "other provider")
-    expect(new_user).to be_valid
-  end
-
   it "is invalid when email doesn't look like an email address" do
     user.email = "dave.example.test"
     expect(user).to be_invalid
+  end
+
+  it "is invalid when email is duplicated" do
+    new_user = FactoryGirl.build(:user, email: user.email)
+    expect(new_user).to be_invalid
   end
 
   describe ".from_omniauth" do
@@ -53,20 +38,8 @@ RSpec.describe User, type: :model do
       expect(subject.last_name).to eq("Doe")
     end
 
-    it "creates a user with the expected provider" do
-      expect(subject.provider).to eq("google_oauth2")
-    end
-
-    it "creates a user with the expected uid" do
-      expect(subject.uid).to eq("123456789")
-    end
-
-    it "creates a user with the expected oauth_token" do
-      expect(subject.oauth_token).to eq("token")
-    end
-
-    it "creates a user with the expected oauth_expires_at" do
-      expect(subject.oauth_expires_at).to eq(Time.at(1354920555))
+    it "creates a user with the expected email" do
+      expect(subject.email).to eq("john@companyname.com")
     end
   end
 


### PR DESCRIPTION
This PR uses the separate authorization tables to manage omniauth.