### PR TITLE
Remove authorization columns from users table

### DIFF
--- a/db/migrate/20170430162820_remove_authorizations_from_user.rb
+++ b/db/migrate/20170430162820_remove_authorizations_from_user.rb
@@ -1,0 +1,8 @@
+class RemoveAuthorizationsFromUser < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :provider
+    remove_column :users, :uid
+    remove_column :users, :oauth_token
+    remove_column :users, :oauth_expires_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170430161718) do
+ActiveRecord::Schema.define(version: 20170430162820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,18 +45,13 @@ ActiveRecord::Schema.define(version: 20170430161718) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "provider"
-    t.string   "uid"
     t.string   "first_name"
     t.string   "last_name"
-    t.string   "oauth_token"
-    t.datetime "oauth_expires_at"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-    t.string   "email",            null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.string   "email",           null: false
     t.string   "password_digest"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
-    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true, using: :btree
   end
 
 end


### PR DESCRIPTION
This PR removes now not needed authorization columns from the users table.