### PR TITLE
Handle if user without password tries to authenticate with password

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
   def login_attempt
     user = User.where(email: params[:email]).first
 
-    if user && user.authenticate(params[:password])
+    if user&.authenticates_with_password? && user&.authenticate(params[:password])
       session[:user_id] = user.id
       redirect_to shares_path
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  NO_PASSWORD_DIGEST = "NA"
+
   has_secure_password
 
   validates :password, length: { minimum: 6 }, allow_nil: true
@@ -18,11 +20,15 @@ class User < ApplicationRecord
     where(email: auth.info.email).first_or_create(
       first_name: auth.info.first_name,
       last_name: auth.info.last_name,
-      password_digest: "NA",
+      password_digest: NO_PASSWORD_DIGEST,
     )
   end
 
   def full_name
     [first_name, last_name].join(" ")
+  end
+
+  def authenticates_with_password?
+    password_digest != NO_PASSWORD_DIGEST
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe SessionsController, type: :controller do
   end
 
   describe "POST #login_attempt" do
+    let!(:existing_oauth_user) { FactoryGirl.create(:user, password_digest: "NA", email: "hank@globex.com") }
     let!(:existing_user) { FactoryGirl.create(:user, password: "password", password_confirmation: "password") }
 
     context "when the provided email and password match a user" do
@@ -23,9 +24,23 @@ RSpec.describe SessionsController, type: :controller do
       end
     end
 
-    context "when the provided email and password don't match a user" do
+    context "when the password doesn't match the users password" do
       it "redirects to the login_path" do
         post :login_attempt, params: { email: existing_user.email, password: "123456" }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context "when the provided email matches an oauth user" do
+      it "redirects to the login_path" do
+        post :login_attempt, params: { email: existing_oauth_user.email, password: "123456" }
+        expect(response).to redirect_to(login_path)
+      end
+    end
+
+    context "when the provided email doesn't match any user" do
+      it "redirects to the login_path" do
+        post :login_attempt, params: { email: "an@other.test", password: "123456" }
         expect(response).to redirect_to(login_path)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,4 +53,16 @@ RSpec.describe User, type: :model do
       expect(subject.full_name).to eq("#{subject.first_name} #{subject.last_name}")
     end
   end
+
+  describe "#authenticates_with_password?" do
+    it "is false if the password digest is 'NA'" do
+      user.password_digest = "NA"
+      expect(user.authenticates_with_password?).to eq(false)
+    end
+
+    it "is false if the user has a bcrypt password digest" do
+      user.update(password: "password", password_confirmation: "password")
+      expect(user.authenticates_with_password?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
This PR ensures that users that have never authenticated with a password (and don't have a valid password digest) do not cause an error if they try to log in with a password.